### PR TITLE
Fix: Wrap special characters in double quotes for correct CSV formatting

### DIFF
--- a/BuildTimeAnalyzer/CMResultWindowController.swift
+++ b/BuildTimeAnalyzer/CMResultWindowController.swift
@@ -159,9 +159,10 @@ class CMResultWindowController: NSWindowController {
     @IBAction func exportCSVClicked(sender: AnyObject) {
 
         let csvString = NSMutableString()
-        csvString.appendString("Time, Path, Code, Filename, References\n")
+        csvString.appendString("Time,File,Code,Reference Count,Path\n")
         for measurement in dataSource where measurement.time > 0{
-            csvString.appendString("\(measurement.time),\(measurement.path),\(measurement.code.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())),\(measurement.filename),\(measurement.references) \n")
+            let codeRef = measurement.code.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+            csvString.appendString("\"\(measurement.time)\",\"\(measurement.filename)\",\"\(codeRef)\",\"\(measurement.references)\",\"\(measurement.path)\"\n")
         }
 
         // Converting it to NSData.


### PR DESCRIPTION
<b>Description:</b> Fix wrap special characters in double quotes for correct CSV formatting

<img width="913" alt="screen shot 2016-08-18 at 11 13 50 am" src="https://cloud.githubusercontent.com/assets/6222533/17785249/dcdb2c26-6534-11e6-8025-8c4758a4de37.png">
