### PR TITLE
Fix: Crash when tapping on file in the 'perFile' view.

### DIFF
--- a/BuildTimeAnalyzer/CMCompileMeasure.swift
+++ b/BuildTimeAnalyzer/CMCompileMeasure.swift
@@ -62,7 +62,7 @@ struct CMCompileMeasure {
         self.code = ""
         self.path = filepath
         self.filename = filename
-        self.locationArray = [0,0]
+        self.locationArray = [1,1]
         self.references = 1
     }
 


### PR DESCRIPTION
<b>Description</b> Fix crash when tapping on file in the 'perFile' view. Crash due to out of bounds location values.
